### PR TITLE
build(nix): build extension with nix and add "code" app

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,4 @@
 has nix && use flake
+watch_file vsix.nix
 dotenv_if_exists .env # You can create a .env file with your env vars for this project. You can also use .secrets if you are using act. See the line below.
 dotenv_if_exists .secrets # Used by [act](https://nektosact.com/) to load secrets into the pipelines

--- a/flake.nix
+++ b/flake.nix
@@ -26,16 +26,49 @@
         );
     in
     {
+      packages = forEachSystem (
+        pkgs: with pkgs; rec {
+          default = vsix;
+          vsix = callPackage ./vsix.nix { };
+
+          sysdig-vscode-ext = vscode-utils.buildVscodeExtension {
+            inherit (vsix.packageJson) name version;
+            src = vsix;
+            unpackPhase = "unzip $src";
+
+            vscodeExtPublisher = vsix.packageJson.publisher;
+            vscodeExtName = vsix.packageJson.name;
+            vscodeExtUniqueId = "${vsix.packageJson.publisher}.${vsix.packageJson.name}";
+          };
+        }
+      );
+
+      apps = forEachSystem (pkgs: {
+        # Builds the extension and packages is with vscode to launch it.
+        # To execute with: nix run .#code
+        # You can also execute it with the latest version in the repo: nix run github:sysdiglabs/vscode-extension#code
+        # Or even from a tag: nix run github:sysdiglabs/vscode-extension/0.2.6#code
+        code =
+          let
+            vscode-with-extension-installed = pkgs.vscode-with-extensions.override {
+              vscodeExtensions = [ self.packages.${pkgs.system}.sysdig-vscode-ext ];
+            };
+          in
+          {
+            type = "app";
+            program = "${vscode-with-extension-installed}/bin/code";
+          };
+      });
+
       devShells = forEachSystem (
         pkgs: with pkgs; {
           default = mkShell {
             shellHook = ''
-              npm install
+              npm ci
             '';
-
             buildInputs = [
               vscode
-              nodejs_22
+              nodejs
               typescript
               vsce
               nodePackages.typescript-language-server

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,33 +4,6 @@
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
-    "": {
-      "name": "sysdig-vscode-ext",
-      "version": "0.2.6",
-      "dependencies": {
-        "@types/js-yaml": "^4.0.9",
-        "dockerfile-ast": "^0.6.1",
-        "js-yaml": "^4.1.0",
-        "yaml-ast-parser": "^0.0.43"
-      },
-      "devDependencies": {
-        "@types/mocha": "^10.0.6",
-        "@types/node": "18.x",
-        "@types/sinon": "^17.0.3",
-        "@types/vscode": "^1.87.0",
-        "@typescript-eslint/eslint-plugin": "^7.4.0",
-        "@typescript-eslint/parser": "^7.4.0",
-        "@vscode/test-cli": "^0.0.8",
-        "@vscode/test-electron": "^2.3.9",
-        "@vscode/vsce": "^2.27.0",
-        "eslint": "^8.57.0",
-        "sinon": "^18.0.0",
-        "typescript": "^5.5.4"
-      },
-      "engines": {
-        "vscode": "^1.87.0"
-      }
-    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",

--- a/vsix.nix
+++ b/vsix.nix
@@ -1,0 +1,36 @@
+{
+  buildNpmPackage,
+  pkg-config,
+  vsce,
+  libsecret,
+}:
+let
+  packageJson = with builtins; fromJSON (readFile ./package.json);
+in
+buildNpmPackage {
+  pname = "${packageJson.name}-vsix";
+  version = packageJson.version;
+  src = ./.;
+  npmDepsHash = "sha256-MRbMbyMFyUr2tetIKMzUoxCVg0eR9oGPU/ecZV5pgq8=";
+
+  nativeBuildInputs = [
+    pkg-config
+    vsce
+  ];
+  buildInputs = [ libsecret ];
+
+  dontNpmBuild = true;
+  dontNpmInstall = true;
+
+  buildPhase = ''
+    vsce package
+  '';
+
+  installPhase = ''
+    install -Dm444 *.vsix $out
+  '';
+
+  passthru = {
+    inherit packageJson;
+  };
+}


### PR DESCRIPTION
Building the extension with nix will ensure the reproducibility. Also the new app "code" that can be executed with `nix run .#code` allows to launch a VSCode instance with the extension installed. This can be used for testing or demo purposes.