### PR TITLE
fix(nix): derive npm deps from lockfile via importNpmLock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,3 @@ repos:
     - ts
     - json
     pass_filenames: false
-  - id: rehash
-    name: rehash
-    language: system
-    entry: just rehash-npm-nix
-    pass_filenames: false

--- a/Justfile
+++ b/Justfile
@@ -19,7 +19,6 @@ update:
     nix flake update
     nix develop --command pre-commit autoupdate
     nix develop --command npm update
-    nix develop --command just rehash-npm-nix
     nix develop --command just update-scanner-version
     nix develop --command pinact run -u --diff
 
@@ -31,6 +30,3 @@ update-scanner-version:
     echo "Latest: $latest"
     sd "(export const SCANNER_VERSION : string = ')[^']+(';)" "\${1}$latest\${2}" src/config/configScanner.ts
     echo "Version updated"
-
-rehash-npm-nix:
-    sd 'npmDepsHash = ".*";' "npmDepsHash = \"$(nix hash convert --to sri $(prefetch-npm-deps ./package-lock.json))\";" vsix.nix

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,6 @@
                 nodejs
                 pinact
                 pre-commit
-                prefetch-npm-deps
                 sd
                 typescript
                 typescript-language-server

--- a/vsix.nix
+++ b/vsix.nix
@@ -1,6 +1,7 @@
 {
   buildNpmPackage,
   clang_20,
+  importNpmLock,
   lib,
   libsecret,
   pkg-config,
@@ -14,7 +15,12 @@ buildNpmPackage {
   pname = "${packageJson.name}-vsix";
   version = packageJson.version;
   src = ./.;
-  npmDepsHash = "sha256-07D441mHQIGb9kR6B/JVv/z+Y4bj5W7zI7+xgDP6qqI=";
+
+  # Derive npm dependencies directly from package-lock.json instead of pinning
+  # a fixed-output npmDepsHash. This way dependency bumps (e.g. Dependabot PRs)
+  # don't require manually updating a hash to keep the Nix build green.
+  npmDeps = importNpmLock { npmRoot = ./.; };
+  npmConfigHook = importNpmLock.npmConfigHook;
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Problem

Every Dependabot dependency PR fails the `test-nix` check with a Nix hash mismatch, e.g.:

```
error: hash mismatch for sysdig-vscode-ext-vsix-…-npm-deps
To correct the hash mismatch … use "sha256-…"
```

`vsix.nix` pins a fixed-output `npmDepsHash` derived from `package-lock.json`. Any lockfile change (i.e. every dependency bump) changes that hash, so the build fails until the hash is manually updated — something Dependabot cannot do. This blocks PRs #40, #41, #42, #44, #46 and every future bump.

## Fix

Replace the pinned `npmDepsHash` with `importNpmLock`, which reads dependencies directly from `package-lock.json` with no fixed-output hash:

```nix
npmDeps = importNpmLock { npmRoot = ./.; };
npmConfigHook = importNpmLock.npmConfigHook;
```

After this, dependency bumps no longer touch any Nix hash — `test-nix` stays green on a plain rebase.

## Verification

Built locally on macOS against `nixpkgs-unstable`:

```
$ nix build .#sysdig-vscode-vsix
…
DONE  Packaged: sysdig-vscode-ext-0.2.16.vsix (198 files, 353.03 KB)
```

## Follow-up

Once merged, the open Dependabot PRs just need `@dependabot rebase` to go green — no per-PR hash edits.